### PR TITLE
feat: uploadImage 웹뷰 브릿지 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,9 +21,8 @@ import Toast from 'react-native-toast-message';
 import {WebView, WebViewMessageEvent} from 'react-native-webview';
 
 import WebViewMessageSender from './modules/WebViewMessageSender';
-import WebViewMessageReceiver, {
-  MemochatWebViewMessage,
-} from './modules/WebViewMessageReceiver';
+import WebViewMessageReceiver from './modules/WebViewMessageReceiver';
+import {WebToNativeCallbackMessage, WebToNativeMessage} from './modules/types';
 
 const screen = Dimensions.get('screen');
 
@@ -56,7 +55,9 @@ const App = () => {
 
   const handleMessage = (event: WebViewMessageEvent) => {
     const {nativeEvent} = event;
-    const message = JSON.parse(nativeEvent.data) as MemochatWebViewMessage;
+    const message = JSON.parse(nativeEvent.data) as
+      | WebToNativeMessage
+      | WebToNativeCallbackMessage;
 
     const webViewMessageReceiver = new WebViewMessageReceiver();
     const webViewMessageSender = new WebViewMessageSender(webViewRef.current);
@@ -70,7 +71,6 @@ const App = () => {
         webViewMessageReceiver.callbackTest(message);
         setTimeout(() => {
           webViewMessageSender.callbackTest({
-            action: message.action,
             callbackId: message.callbackId,
           });
         }, 1000);

--- a/__tests__/App-test.tsx
+++ b/__tests__/App-test.tsx
@@ -4,7 +4,7 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import App from '../src/App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
   package="com.memochatapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="18"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
       android:name=".MainApplication"

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  */
 
 import {AppRegistry} from 'react-native';
-import App from './App';
+import App from './src/App';
 import {name as appName} from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/ios/MemochatApp/Info.plist
+++ b/ios/MemochatApp/Info.plist
@@ -37,6 +37,10 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSCameraUsageDescription</key>
+	<string>사진 메모를 남기기 위해 필요한 권한입니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진 메모를 남기기 위해 필요한 권한입니다.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -302,6 +302,8 @@ PODS:
   - React-jsinspector (0.70.5)
   - React-logger (0.70.5):
     - glog
+  - react-native-image-picker (4.10.2):
+    - React-Core
   - react-native-webview (11.23.1):
     - React-Core
   - React-perflogger (0.70.5)
@@ -422,6 +424,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -498,6 +501,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-image-picker:
+    :path: "../node_modules/react-native-image-picker"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-perflogger:
@@ -562,6 +567,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 31564fa6912459921568e8b0e49024285a4d584b
   React-jsinspector: badd81696361249893a80477983e697aab3c1a34
   React-logger: fdda34dd285bdb0232e059b19d9606fa0ec3bb9c
+  react-native-image-picker: bf34f3f516d139ed3e24c5f5a381a91819e349ea
   react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
   React-perflogger: e68d3795cf5d247a0379735cbac7309adf2fb931
   React-RCTActionSheet: 05452c3b281edb27850253db13ecd4c5a65bc247

--- a/modules/WebViewMessageReceiver.ts
+++ b/modules/WebViewMessageReceiver.ts
@@ -1,10 +1,8 @@
 import Toast from 'react-native-toast-message';
-
-export interface MemochatWebViewMessage {
-  action: 'test' | 'callback-test'; //TODO: union으로 정의
-  args?: Record<string, unknown>;
-  callbackId?: string;
-}
+import {
+  TestWebToNativeMessage,
+  CallbackTestWebToNativeCallbackMessage,
+} from './types';
 
 class WebViewMessageReceiver {
   static instance: WebViewMessageReceiver;
@@ -17,7 +15,7 @@ class WebViewMessageReceiver {
     return WebViewMessageReceiver.instance;
   }
 
-  test(message: MemochatWebViewMessage) {
+  test(message: TestWebToNativeMessage) {
     Toast.show({
       type: 'info', //success, error, info
       text1: message.action,
@@ -26,7 +24,7 @@ class WebViewMessageReceiver {
     console.log(message);
   }
 
-  callbackTest(message: MemochatWebViewMessage) {
+  callbackTest(message: CallbackTestWebToNativeCallbackMessage) {
     Toast.show({
       type: 'info', //success, error, info
       text1: message.action,

--- a/modules/WebViewMessageSender.ts
+++ b/modules/WebViewMessageSender.ts
@@ -1,9 +1,5 @@
 import WebView from 'react-native-webview';
-import {
-  MemochatNativeToWebCallbackResponseMessage,
-  MemochatNativeToWebMessage,
-  MemochatWebToNativeMessage,
-} from './types';
+import {NativeToWebCallbackMessage, NativeToWebMessage} from './types';
 
 /**
  * webview로 메시지 보내는 브릿지
@@ -24,41 +20,39 @@ class WebViewMessageSender {
     return WebViewMessageSender.instance;
   }
 
-  private buildNativeToWebCallbackMessage(
-    params: MemochatNativeToWebCallbackResponseMessage,
-  ) {
-    const message = `window.MemochatWebview.postNativeToWebCallbackMessage(${JSON.stringify(
-      params,
-    )})`;
-    return message;
+  private postNativeToWebCallbackMessage(message: NativeToWebCallbackMessage) {
+    WebViewMessageSender.webViewRef.injectJavaScript(
+      `window.MemochatWebview.postNativeToWebCallbackMessage(${JSON.stringify(
+        message,
+      )})`,
+    );
   }
 
-  private buildNativeToWebMessage(params: MemochatNativeToWebMessage) {
+  private postNativeToWebMessage(message: NativeToWebMessage) {
     /*
       action: MemochatNativeToWebActions;
       data?: Record<string, unknown>;
       callbackId?: string;
     */
-    const message = `window.MemochatWebview.postNativeToWebMessage(${JSON.stringify(
-      params,
-    )})`;
-    return message;
+    WebViewMessageSender.webViewRef.injectJavaScript(
+      `window.MemochatWebview.postNativeToWebMessage(${JSON.stringify(
+        message,
+      )})`,
+    );
   }
 
   back() {
-    const message = this.buildNativeToWebMessage({action: 'back'});
-    WebViewMessageSender.webViewRef.injectJavaScript(message);
+    this.postNativeToWebMessage({action: 'back'});
   }
 
-  callbackTest(params: MemochatWebToNativeMessage) {
-    const message = this.buildNativeToWebCallbackMessage({
-      action: params.action,
+  callbackTest({callbackId}: {callbackId: string}) {
+    this.postNativeToWebCallbackMessage({
+      action: 'callback-test',
       data: {
         message: 'hello',
       },
-      callbackId: params.callbackId,
+      callbackId,
     });
-    WebViewMessageSender.webViewRef.injectJavaScript(message);
   }
 }
 

--- a/modules/types.ts
+++ b/modules/types.ts
@@ -1,27 +1,56 @@
-export type MemochatWebToNativeActions = 'test' | 'callback-test';
+//web to native message
+export type WebToNativeMessage = TestWebToNativeMessage;
 
-export type MemochatWebToNativeMessage = {
-  action: MemochatWebToNativeActions;
-  args?: string; // Record<string, unknown>;
-  callbackId?: string;
+export type WebToNativeAction = WebToNativeMessage['action'];
+
+export type TestWebToNativeMessage = {
+  action: 'test';
 };
 
-export type MemochatNativeToWebCallbackResponseMessage = {
-  action: MemochatWebToNativeActions;
+// web to native callback message
+export type WebToNativeCallbackMessage =
+  | CallbackTestWebToNativeCallbackMessage
+  | UploadImageWebToNativeCallbackMessage;
+export type WebToNativeCallbackAction = WebToNativeCallbackMessage['action'];
+
+export type CallbackTestWebToNativeCallbackMessage = {
+  action: 'callback-test';
+  args?: Record<string, unknown>;
+  callbackId: string;
+};
+
+export type UploadImageWebToNativeCallbackMessage = {
+  action: 'upload-image';
+  args: {
+    type: 'camera' | 'gallery';
+  };
+  callbackId: string;
+};
+
+// native to web callback response message
+export type NativeToWebCallbackMessage =
+  | CallbackTestNativeToWebCallbackMessage
+  | UploadImageNativeToWebCallbackMessage;
+export type NativeToWebCallbackAction = NativeToWebCallbackMessage['action'];
+
+export type CallbackTestNativeToWebCallbackMessage = {
+  action: 'callback-test';
   data?: Record<string, unknown>;
   error?: Record<string, unknown>;
   callbackId?: string;
 };
 
-export type MemochatNativeToWebActions = 'back';
-
-export type MemochatNativeToWebMessage = {
-  action: MemochatNativeToWebActions;
-  data?: Record<string, unknown>;
+export type UploadImageNativeToWebCallbackMessage = {
+  action: 'upload-image';
+  data?: {imageUrl: string};
+  error?: Record<string, unknown>;
   callbackId?: string;
 };
 
-export type MemochatWebToNativeRequestParams = {
-  action: MemochatWebToNativeActions;
-  args?: Record<string, unknown>;
+// native to web message
+export type NativeToWebMessage = BackNativeToWebMessage;
+export type NativeToWebAction = NativeToWebMessage['action'];
+
+type BackNativeToWebMessage = {
+  action: 'back';
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "18.1.0",
     "react-native": "0.70.5",
+    "react-native-image-picker": "^4.10.2",
     "react-native-toast-message": "^2.1.5",
     "react-native-webview": "^11.23.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ const App = () => {
     };
   }, []);
 
-  const handleMessage = (event: WebViewMessageEvent) => {
+  const handleMessage = async (event: WebViewMessageEvent) => {
     const {nativeEvent} = event;
     const message = JSON.parse(nativeEvent.data) as
       | WebToNativeMessage
@@ -70,10 +70,18 @@ const App = () => {
       case 'callback-test': {
         webViewMessageReceiver.callbackTest(message);
         setTimeout(() => {
-          webViewMessageSender.callbackTest({
+          webViewMessageSender.callbackTestCallback({
             callbackId: message.callbackId,
           });
         }, 1000);
+        return;
+      }
+      case 'upload-image': {
+        const formData = await webViewMessageReceiver.uploadImage(message);
+        webViewMessageSender.uploadImageCallback({
+          formData,
+          callbackId: message.callbackId,
+        });
         return;
       }
       default: {

--- a/src/modules/WebViewMessageReceiver.ts
+++ b/src/modules/WebViewMessageReceiver.ts
@@ -1,7 +1,9 @@
 import Toast from 'react-native-toast-message';
+import {openCamera, openGallery, parseFormData} from '../utils/imagePicker';
 import {
   TestWebToNativeMessage,
   CallbackTestWebToNativeCallbackMessage,
+  UploadImageWebToNativeCallbackMessage,
 } from './types';
 
 class WebViewMessageReceiver {
@@ -30,6 +32,33 @@ class WebViewMessageReceiver {
       text1: message.action,
       text2: JSON.stringify(message),
     });
+  }
+
+  async uploadImage(
+    message: UploadImageWebToNativeCallbackMessage,
+  ): Promise<FormData | undefined> {
+    try {
+      switch (message.args.type) {
+        case 'camera': {
+          const asset = await openCamera();
+          if (!asset) {
+            return;
+          }
+          const formData = parseFormData(asset);
+          return formData;
+        }
+        case 'gallery': {
+          const asset = await openGallery();
+          if (!asset) {
+            return;
+          }
+          const formData = parseFormData(asset);
+          return formData;
+        }
+      }
+    } catch (error) {
+      console.log(JSON.stringify(error));
+    }
   }
 }
 

--- a/src/modules/WebViewMessageSender.ts
+++ b/src/modules/WebViewMessageSender.ts
@@ -45,11 +45,40 @@ class WebViewMessageSender {
     this.postNativeToWebMessage({action: 'back'});
   }
 
-  callbackTest({callbackId}: {callbackId: string}) {
+  callbackTestCallback({callbackId}: {callbackId: string}) {
     this.postNativeToWebCallbackMessage({
       action: 'callback-test',
       data: {
         message: 'hello',
+      },
+      callbackId,
+    });
+  }
+
+  uploadImageCallback({
+    formData,
+    callbackId,
+  }: {
+    formData: FormData | undefined;
+    callbackId: string;
+  }) {
+    console.log('formData: ', formData);
+    if (!formData) {
+      this.postNativeToWebCallbackMessage({
+        action: 'upload-image',
+        error: {
+          message: '이미지 호출 실패',
+        },
+        callbackId,
+      });
+      return;
+    }
+
+    // TODO: 이미지 업로드 api 호출
+    this.postNativeToWebCallbackMessage({
+      action: 'upload-image',
+      data: {
+        imageUrl: 'imageUrl',
       },
       callbackId,
     });

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -33,17 +33,22 @@ export type NativeToWebCallbackMessage =
   | UploadImageNativeToWebCallbackMessage;
 export type NativeToWebCallbackAction = NativeToWebCallbackMessage['action'];
 
+export type NativeToWebCallbackMessageError = {
+  type?: string;
+  message?: string;
+};
+
 export type CallbackTestNativeToWebCallbackMessage = {
   action: 'callback-test';
   data?: Record<string, unknown>;
-  error?: Record<string, unknown>;
+  error?: NativeToWebCallbackMessageError;
   callbackId?: string;
 };
 
 export type UploadImageNativeToWebCallbackMessage = {
   action: 'upload-image';
   data?: {imageUrl: string};
-  error?: Record<string, unknown>;
+  error?: NativeToWebCallbackMessageError;
   callbackId?: string;
 };
 

--- a/src/utils/imagePicker.ts
+++ b/src/utils/imagePicker.ts
@@ -1,0 +1,80 @@
+import {PermissionsAndroid, Platform} from 'react-native';
+
+import {
+  Asset,
+  launchCamera,
+  launchImageLibrary,
+} from 'react-native-image-picker';
+
+// 안드로이드에서만 CAMERA, WRITE_EXTERNAL_STORAGE 권한 체크
+const checkCameraPermission = async (): Promise<boolean> => {
+  if (Platform.OS !== 'android') {
+    return true;
+  }
+
+  const grantedCamera = await PermissionsAndroid.request(
+    PermissionsAndroid.PERMISSIONS.CAMERA,
+  );
+  const grantedStorage = await PermissionsAndroid.request(
+    PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+  );
+
+  return [grantedCamera, grantedStorage].every(
+    granted => granted === PermissionsAndroid.RESULTS.GRANTED,
+  );
+};
+
+export const openCamera = async (): Promise<Asset | undefined> => {
+  const isCameraPermissionGiven = await checkCameraPermission();
+  if (!isCameraPermissionGiven) {
+    return;
+  }
+
+  const result = await launchCamera({
+    mediaType: 'photo',
+    cameraType: 'back',
+  });
+
+  if (result.didCancel || !result.assets) {
+    return;
+  }
+
+  return result.assets[0];
+};
+
+const IMAGE_SELECTION_LIMIT = 10;
+
+export const openGallery = async (): Promise<Asset | Asset[] | undefined> => {
+  const result = await launchImageLibrary({
+    mediaType: 'photo',
+    selectionLimit: IMAGE_SELECTION_LIMIT,
+  });
+
+  if (result.didCancel || !result.assets) {
+    return;
+  }
+
+  if (result.assets.length === 1) {
+    return result.assets[0];
+  }
+
+  return result.assets;
+};
+
+export const parseFormData = (assets: Asset | Asset[]): FormData => {
+  const data = new FormData();
+
+  (Array.isArray(assets) ? assets : [assets]).forEach(asset => {
+    data.append(
+      'file',
+      JSON.stringify({
+        type: asset.type,
+        name: asset.fileName,
+        size: asset.fileSize,
+        data: `data:${asset.type};base64,${asset.uri}`,
+      }),
+    );
+  });
+
+  return data;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,6 +5715,11 @@ react-native-gradle-plugin@^0.70.3:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz#cbcf0619cbfbddaa9128701aa2d7b4145f9c4fc8"
   integrity sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==
 
+react-native-image-picker@^4.10.2:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-4.10.2.tgz#75b356c9eea70c2c4f5c1089f8758e2fa32f88a8"
+  integrity sha512-3h9PrA1dQ84rVeipzQE4eWTELvflSHNtJZN6rz7NkZyaxo9YZV8H/TswBpHwiS5YWlyu+zlLzSoWVa1opSu7GA==
+
 react-native-toast-message@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.1.5.tgz#550acb9c6c0f1ee49c6b57b65a56d34e297eb723"


### PR DESCRIPTION
## 📍 주요 변경사항

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

웹뷰에서 갤러리 버튼을 누르면 갤러리를 띄우고, 카메라 버튼을 누르면 카메라 여는 기능 구현

* 앱-웹의 통신 관련 타입을 웹과 동일하게 통일시켰습니다. 
  (type.ts 파일의 경우 웹과 완전히 동일, 복붙하여 사용하도록 -> 추후 npm 패키지로 분리 하면 좋을 듯합니다.)

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

동작은 아래 pr 과 동일합니다
https://github.com/memochat/memochat-app/pull/2

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
